### PR TITLE
feat(controller): use resourceVersion-guarded patches to avoid clobbering concurrent writes

### DIFF
--- a/analysis/controller.go
+++ b/analysis/controller.go
@@ -33,6 +33,7 @@ import (
 	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
+	resourceversionutil "github.com/argoproj/argo-rollouts/utils/resourceversion"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 )
 
@@ -71,6 +72,10 @@ type Controller struct {
 	// Kubernetes API.
 	recorder     record.EventRecorder
 	resyncPeriod time.Duration
+
+	// analysisRunVersionTracker remembers ResourceVersions from our last successful writes so
+	// syncHandler can requeue when the informer cache hasn't caught up yet.
+	analysisRunVersionTracker *resourceversionutil.Tracker
 }
 
 // ControllerConfig describes the data required to instantiate a new analysis controller
@@ -98,6 +103,8 @@ func NewController(cfg ControllerConfig) *Controller {
 		analysisRunSynced:    cfg.AnalysisRunInformer.Informer().HasSynced,
 		recorder:             cfg.Recorder,
 		resyncPeriod:         cfg.ResyncPeriod,
+
+		analysisRunVersionTracker: resourceversionutil.NewTracker(),
 	}
 
 	controller.enqueueAnalysis = func(obj any) {
@@ -173,10 +180,15 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	run, err := c.analysisRunLister.AnalysisRuns(namespace).Get(name)
 	if k8serrors.IsNotFound(err) {
 		log.WithField(logutil.AnalysisRunKey, name).WithField(logutil.NamespaceKey, namespace).Info("Analysis has been deleted")
+		c.analysisRunVersionTracker.Forget(key)
 		return nil
 	}
 	if err != nil {
 		return err
+	}
+
+	if c.analysisRunVersionTracker.IsCacheStale(key, run.ResourceVersion) {
+		return controllerutil.StaleCacheError
 	}
 
 	defer func() {

--- a/analysis/controller_test.go
+++ b/analysis/controller_test.go
@@ -17,6 +17,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	informers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions"
+	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	"github.com/argoproj/argo-rollouts/utils/record"
 )
 
@@ -382,6 +384,56 @@ func TestFailedToCreateProviderError(t *testing.T) {
 
 	assert.Equal(t, v1alpha1.AnalysisPhaseError, updatedAr.Status.MetricResults[0].Measurements[0].Phase)
 	assert.Equal(t, "failed to create provider", updatedAr.Status.MetricResults[0].Measurements[0].Message)
+}
+
+// TestSyncAnalysisRunStaleCache verifies the syncHandler short-circuits with StaleCacheError when
+// the informer cache is behind a ResourceVersion we previously wrote.
+func TestSyncAnalysisRunStaleCache(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	run := newRun()
+	run.Name = "test"
+	run.Namespace = metav1.NamespaceDefault
+	run.ResourceVersion = "100"
+	f.analysisRunLister = append(f.analysisRunLister, run)
+	f.objects = append(f.objects, run)
+
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	i.Start(stopCh)
+	k8sI.Start(stopCh)
+	assert.True(t, cache.WaitForCacheSync(stopCh, c.analysisRunSynced))
+
+	// We recorded a newer write than what the cache currently has.
+	c.analysisRunVersionTracker.Record("default/test", "200")
+
+	err := c.syncHandler(context.Background(), "default/test")
+	assert.ErrorIs(t, err, controllerutil.StaleCacheError)
+}
+
+// TestPersistAnalysisRunStatusConflictRequeue verifies a 409 Conflict on the status patch is mapped
+// to StaleCacheError so the item is requeued rather than treated as a fatal error.
+func TestPersistAnalysisRunStatusConflictRequeue(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	orig := newRun()
+	orig.Name = "test"
+	orig.Namespace = metav1.NamespaceDefault
+	orig.ResourceVersion = "100"
+
+	c, _, _ := f.newController(noResyncPeriodFunc)
+	f.client.PrependReactor("patch", "analysisruns", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "analysisruns"}, orig.Name, fmt.Errorf("conflict"))
+	})
+
+	newStatus := orig.Status.DeepCopy()
+	newStatus.Phase = v1alpha1.AnalysisPhaseSuccessful
+
+	err := c.persistAnalysisRunStatus(orig, *newStatus)
+	assert.ErrorIs(t, err, controllerutil.StaleCacheError)
 }
 
 func TestRun(t *testing.T) {

--- a/analysis/sync.go
+++ b/analysis/sync.go
@@ -3,10 +3,12 @@ package analysis
 import (
 	"context"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	patchtypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	"github.com/argoproj/argo-rollouts/utils/diff"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 )
@@ -14,13 +16,13 @@ import (
 func (c *Controller) persistAnalysisRunStatus(orig *v1alpha1.AnalysisRun, newStatus v1alpha1.AnalysisRunStatus) error {
 	ctx := context.TODO()
 	logCtx := logutil.WithAnalysisRun(orig)
-	patch, modified, err := diff.CreateTwoWayMergePatch(
+	patch, modified, err := diff.CreateTwoWayMergePatchWithResourceVersion(
 		&v1alpha1.AnalysisRun{
 			Status: orig.Status,
 		},
 		&v1alpha1.AnalysisRun{
 			Status: newStatus,
-		}, v1alpha1.AnalysisRun{})
+		}, v1alpha1.AnalysisRun{}, orig.ResourceVersion)
 	if err != nil {
 		logCtx.Errorf("Error constructing AnalysisRun status patch: %v", err)
 		return err
@@ -30,11 +32,18 @@ func (c *Controller) persistAnalysisRunStatus(orig *v1alpha1.AnalysisRun, newSta
 		return nil
 	}
 	logCtx.Debugf("AnalysisRun Patch: %s", patch)
-	_, err = c.argoProjClientset.ArgoprojV1alpha1().AnalysisRuns(orig.Namespace).Patch(ctx, orig.Name, patchtypes.MergePatchType, patch, metav1.PatchOptions{})
+	patched, err := c.argoProjClientset.ArgoprojV1alpha1().AnalysisRuns(orig.Namespace).Patch(ctx, orig.Name, patchtypes.MergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
+		if k8serrors.IsConflict(err) {
+			// A concurrent write landed since we read from cache; requeue and retry against fresh
+			// state rather than clobbering it.
+			logCtx.Infof("Conflict while patching analysisRun, requeuing: %v", err)
+			return controllerutil.StaleCacheError
+		}
 		logCtx.Warningf("Error updating analysisRun: %v", err)
 		return err
 	}
+	c.analysisRunVersionTracker.Record(orig.Namespace+"/"+orig.Name, patched.ResourceVersion)
 	logCtx.Info("Patch status successfully")
 	return nil
 }

--- a/experiments/controller.go
+++ b/experiments/controller.go
@@ -35,6 +35,7 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/diff"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
+	resourceversionutil "github.com/argoproj/argo-rollouts/utils/resourceversion"
 	timeutil "github.com/argoproj/argo-rollouts/utils/time"
 	unstructuredutil "github.com/argoproj/argo-rollouts/utils/unstructured"
 )
@@ -79,6 +80,10 @@ type Controller struct {
 	// Kubernetes API.
 	recorder     record.EventRecorder
 	resyncPeriod time.Duration
+
+	// experimentVersionTracker remembers ResourceVersions from our last successful writes so
+	// syncHandler can requeue when the informer cache hasn't caught up yet.
+	experimentVersionTracker *resourceversionutil.Tracker
 }
 
 // ControllerConfig describes the data required to instantiate a new experiments controller
@@ -126,6 +131,8 @@ func NewController(cfg ControllerConfig) *Controller {
 		clusterAnalysisTemplateSynced: cfg.ClusterAnalysisTemplateInformer.Informer().HasSynced,
 		recorder:                      cfg.Recorder,
 		resyncPeriod:                  cfg.ResyncPeriod,
+
+		experimentVersionTracker: resourceversionutil.NewTracker(),
 	}
 
 	controller.enqueueExperiment = func(obj any) {
@@ -255,10 +262,15 @@ func (ec *Controller) syncHandler(ctx context.Context, key string) error {
 	experiment, err := ec.experimentsLister.Experiments(namespace).Get(name)
 	if k8serrors.IsNotFound(err) {
 		logCtx.Info("Experiment has been deleted")
+		ec.experimentVersionTracker.Forget(key)
 		return nil
 	}
 	if err != nil {
 		return err
+	}
+
+	if ec.experimentVersionTracker.IsCacheStale(key, experiment.ResourceVersion) {
+		return controllerutil.StaleCacheError
 	}
 
 	defer func() {
@@ -322,13 +334,13 @@ func (ec *Controller) persistExperimentStatus(orig *v1alpha1.Experiment, newStat
 	prevStatus := orig.Status
 	ctx := context.TODO()
 	logCtx := logutil.WithExperiment(orig)
-	patch, modified, err := diff.CreateTwoWayMergePatch(
+	patch, modified, err := diff.CreateTwoWayMergePatchWithResourceVersion(
 		&v1alpha1.Experiment{
 			Status: orig.Status,
 		},
 		&v1alpha1.Experiment{
 			Status: *newStatus,
-		}, v1alpha1.Experiment{})
+		}, v1alpha1.Experiment{}, orig.ResourceVersion)
 	if err != nil {
 		logCtx.Errorf("Error constructing app status patch: %v", err)
 		return err
@@ -340,9 +352,16 @@ func (ec *Controller) persistExperimentStatus(orig *v1alpha1.Experiment, newStat
 	logCtx.Debugf("Experiment Patch: %s", patch)
 	patched, err := ec.argoProjClientset.ArgoprojV1alpha1().Experiments(orig.Namespace).Patch(ctx, orig.Name, patchtypes.MergePatchType, patch, metav1.PatchOptions{})
 	if err != nil {
+		if k8serrors.IsConflict(err) {
+			// A concurrent write landed since we read from cache; requeue and retry against fresh
+			// state rather than clobbering it.
+			logCtx.Infof("Conflict while patching experiment, requeuing: %v", err)
+			return controllerutil.StaleCacheError
+		}
 		logCtx.Warningf("Error updating experiment: %v", err)
 		return err
 	}
+	ec.experimentVersionTracker.Record(orig.Namespace+"/"+orig.Name, patched.ResourceVersion)
 	logCtx.Info("Patch status successfully")
 	ec.recordEvent(patched, prevStatus, newStatus)
 	return nil

--- a/experiments/controller_test.go
+++ b/experiments/controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,6 +39,7 @@ import (
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	informers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	"github.com/argoproj/argo-rollouts/utils/record"
 )
 
@@ -918,4 +920,47 @@ func TestRun(t *testing.T) {
 		cancel()
 	}()
 	c.Run(ctx, 1)
+}
+
+// TestSyncExperimentStaleCache verifies the syncHandler short-circuits with StaleCacheError when the
+// informer cache is behind a ResourceVersion we previously wrote.
+func TestSyncExperimentStaleCache(t *testing.T) {
+	ex := newExperiment("test", nil, "")
+	ex.ResourceVersion = "100"
+
+	f := newFixture(t, ex)
+	defer f.Close()
+
+	c, i, k8sI := f.newController(noResyncPeriodFunc)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	i.Start(stopCh)
+	k8sI.Start(stopCh)
+	assert.True(t, cache.WaitForCacheSync(stopCh, c.experimentSynced))
+
+	c.experimentVersionTracker.Record("default/test", "200")
+
+	err := c.syncHandler(context.Background(), "default/test")
+	assert.ErrorIs(t, err, controllerutil.StaleCacheError)
+}
+
+// TestPersistExperimentStatusConflictRequeue verifies a 409 Conflict on the status patch is mapped to
+// StaleCacheError so the item is requeued rather than treated as a fatal error.
+func TestPersistExperimentStatusConflictRequeue(t *testing.T) {
+	f := newFixture(t)
+	defer f.Close()
+
+	orig := newExperiment("test", nil, "")
+	orig.ResourceVersion = "100"
+
+	c, _, _ := f.newController(noResyncPeriodFunc)
+	f.client.PrependReactor("patch", "experiments", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "experiments"}, orig.Name, fmt.Errorf("conflict"))
+	})
+
+	newStatus := orig.Status.DeepCopy()
+	newStatus.Phase = v1alpha1.AnalysisPhaseRunning
+
+	err := c.persistExperimentStatus(orig, newStatus)
+	assert.ErrorIs(t, err, controllerutil.StaleCacheError)
 }

--- a/experiments/replicaset.go
+++ b/experiments/replicaset.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	"github.com/argoproj/argo-rollouts/utils/diff"
 	experimentutil "github.com/argoproj/argo-rollouts/utils/experiment"
 	"github.com/argoproj/argo-rollouts/utils/hash"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
@@ -129,10 +131,19 @@ func (ec *experimentContext) createReplicaSet(template v1alpha1.TemplateSpec, co
 		}
 
 		patch := fmt.Sprintf(CollisionCountPatch, string(templateStatusBytes))
-		_, patchErr := ec.argoProjClientset.ArgoprojV1alpha1().Experiments(ec.ex.Namespace).Patch(ctx, ec.ex.Name, patchtypes.MergePatchType, []byte(patch), metav1.PatchOptions{})
-		ec.log.WithField("patch", patch).Debug("Applied Patch")
+		patchBytes, marshalErr := diff.InjectResourceVersion([]byte(patch), ec.ex.ResourceVersion)
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+		_, patchErr := ec.argoProjClientset.ArgoprojV1alpha1().Experiments(ec.ex.Namespace).Patch(ctx, ec.ex.Name, patchtypes.MergePatchType, patchBytes, metav1.PatchOptions{})
+		ec.log.WithField("patch", string(patchBytes)).Debug("Applied Patch")
 		if patchErr != nil {
-			ec.log.Errorf("Error patching service %s", err.Error())
+			if k8serrors.IsConflict(patchErr) {
+				// A concurrent write landed since we read from cache; requeue and retry against
+				// fresh state rather than clobbering it.
+				return nil, controllerutil.StaleCacheError
+			}
+			ec.log.Errorf("Error patching experiment %s", patchErr.Error())
 			return nil, patchErr
 		}
 		ec.log.Warnf("Found a hash collision - bumped collisionCount (%d->%d) to resolve it", preCollisionCount, *newTemplate.CollisionCount)

--- a/rollout/service.go
+++ b/rollout/service.go
@@ -6,6 +6,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	patchtypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -15,7 +16,9 @@ import (
 	"github.com/argoproj/argo-rollouts/utils/annotations"
 	"github.com/argoproj/argo-rollouts/utils/aws"
 	"github.com/argoproj/argo-rollouts/utils/conditions"
+	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
 	"github.com/argoproj/argo-rollouts/utils/defaults"
+	"github.com/argoproj/argo-rollouts/utils/diff"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	"github.com/argoproj/argo-rollouts/utils/record"
 	replicasetutil "github.com/argoproj/argo-rollouts/utils/replicaset"
@@ -64,8 +67,18 @@ func (c rolloutContext) switchServiceSelector(service *corev1.Service, newRollou
 		return nil
 	}
 	patch := generatePatch(service, newRolloutUniqueLabelValue, r)
-	_, err := c.kubeclientset.CoreV1().Services(service.Namespace).Patch(ctx, service.Name, patchtypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+	patchBytes, err := diff.InjectResourceVersion([]byte(patch), service.ResourceVersion)
 	if err != nil {
+		return err
+	}
+	_, err = c.kubeclientset.CoreV1().Services(service.Namespace).Patch(ctx, service.Name, patchtypes.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		if k8serrors.IsConflict(err) {
+			// The Service was modified concurrently since we read it from cache; requeue and retry
+			// against fresh state rather than clobbering the concurrent change.
+			c.log.Infof("Conflict while switching selector for service %q, requeuing: %v", service.Name, err)
+			return controllerutil.StaleCacheError
+		}
 		return err
 	}
 	msg := fmt.Sprintf("Switched selector for service '%s' from '%s' to '%s'", service.Name, oldPodHash, newRolloutUniqueLabelValue)

--- a/service/service.go
+++ b/service/service.go
@@ -25,6 +25,7 @@ import (
 	clientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	informers "github.com/argoproj/argo-rollouts/pkg/client/informers/externalversions/rollouts/v1alpha1"
 	controllerutil "github.com/argoproj/argo-rollouts/utils/controller"
+	"github.com/argoproj/argo-rollouts/utils/diff"
 	logutil "github.com/argoproj/argo-rollouts/utils/log"
 	serviceutil "github.com/argoproj/argo-rollouts/utils/service"
 	unstructuredutil "github.com/argoproj/argo-rollouts/utils/unstructured"
@@ -204,10 +205,20 @@ func (c *Controller) syncService(ctx context.Context, key string) error {
 
 	patch := generateRemovePatch(svc)
 	if patch != "" {
-		_, err = c.kubeclientset.CoreV1().Services(svc.Namespace).Patch(ctx, svc.Name, patchtypes.MergePatchType, []byte(patch), metav1.PatchOptions{})
+		patchBytes, err := diff.InjectResourceVersion([]byte(patch), svc.ResourceVersion)
+		if err != nil {
+			return err
+		}
+		_, err = c.kubeclientset.CoreV1().Services(svc.Namespace).Patch(ctx, svc.Name, patchtypes.MergePatchType, patchBytes, metav1.PatchOptions{})
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				return nil
+			}
+			if k8serrors.IsConflict(err) {
+				// The Service was modified concurrently since we read it from cache; requeue and
+				// retry against fresh state rather than clobbering the concurrent change.
+				logCtx.Infof("Conflict while cleaning service, requeuing: %v", err)
+				return controllerutil.StaleCacheError
 			}
 			return err
 		}

--- a/utils/diff/diff.go
+++ b/utils/diff/diff.go
@@ -22,3 +22,42 @@ func CreateTwoWayMergePatch(orig, new, dataStruct any) ([]byte, bool, error) {
 	}
 	return patch, string(patch) != "{}", nil
 }
+
+// CreateTwoWayMergePatchWithResourceVersion behaves like CreateTwoWayMergePatch but injects
+// metadata.resourceVersion (which should be the orig object's ResourceVersion) into the patch
+// so the apiserver enforces optimistic concurrency and returns a 409 Conflict when the live
+// object has changed since it was read. The resourceVersion is only injected when there is an
+// actual change, so we never emit a resourceVersion-only patch. When resourceVersion is empty
+// it falls back to the unguarded behavior of CreateTwoWayMergePatch (fail open).
+func CreateTwoWayMergePatchWithResourceVersion(orig, new, dataStruct any, resourceVersion string) ([]byte, bool, error) {
+	patch, modified, err := CreateTwoWayMergePatch(orig, new, dataStruct)
+	if err != nil || !modified {
+		return patch, modified, err
+	}
+	patch, err = InjectResourceVersion(patch, resourceVersion)
+	if err != nil {
+		return nil, false, err
+	}
+	return patch, true, nil
+}
+
+// InjectResourceVersion adds metadata.resourceVersion to an existing JSON merge patch so the
+// apiserver enforces optimistic concurrency. It is a no-op when resourceVersion is empty (fail
+// open). It works for merge and strategic-merge patch bodies (objects), not JSON (RFC 6902)
+// patches, which are arrays.
+func InjectResourceVersion(patch []byte, resourceVersion string) ([]byte, error) {
+	if resourceVersion == "" {
+		return patch, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(patch, &m); err != nil {
+		return nil, err
+	}
+	meta, _ := m["metadata"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	meta["resourceVersion"] = resourceVersion
+	m["metadata"] = meta
+	return json.Marshal(m)
+}

--- a/utils/diff/diff_test.go
+++ b/utils/diff/diff_test.go
@@ -80,3 +80,54 @@ func TestCreateTwoWayMergeNoPatch(t *testing.T) {
 	assert.False(t, isPatched)
 	assert.Equal(t, "{}", string(patch))
 }
+
+func TestCreateTwoWayMergePatchWithResourceVersion(t *testing.T) {
+	orig := v1alpha1.Rollout{Status: v1alpha1.RolloutStatus{Replicas: 1}}
+	updated := v1alpha1.Rollout{Status: v1alpha1.RolloutStatus{Replicas: 2}}
+
+	patch, isPatched, err := CreateTwoWayMergePatchWithResourceVersion(orig, updated, v1alpha1.Rollout{}, "12345")
+	assert.Nil(t, err)
+	assert.True(t, isPatched)
+	assert.Contains(t, string(patch), `"resourceVersion":"12345"`)
+	assert.Contains(t, string(patch), `"status":{"replicas":2}`)
+}
+
+func TestCreateTwoWayMergePatchWithResourceVersionNoChange(t *testing.T) {
+	orig := v1alpha1.Rollout{Status: v1alpha1.RolloutStatus{Replicas: 1}}
+	updated := v1alpha1.Rollout{Status: v1alpha1.RolloutStatus{Replicas: 1}}
+
+	// No status change: must not emit a resourceVersion-only patch.
+	patch, isPatched, err := CreateTwoWayMergePatchWithResourceVersion(orig, updated, v1alpha1.Rollout{}, "12345")
+	assert.Nil(t, err)
+	assert.False(t, isPatched)
+	assert.Equal(t, "{}", string(patch))
+}
+
+func TestCreateTwoWayMergePatchWithResourceVersionEmpty(t *testing.T) {
+	orig := v1alpha1.Rollout{Status: v1alpha1.RolloutStatus{Replicas: 1}}
+	updated := v1alpha1.Rollout{Status: v1alpha1.RolloutStatus{Replicas: 2}}
+
+	// Empty resourceVersion: fail open, behave like CreateTwoWayMergePatch.
+	patch, isPatched, err := CreateTwoWayMergePatchWithResourceVersion(orig, updated, v1alpha1.Rollout{}, "")
+	assert.Nil(t, err)
+	assert.True(t, isPatched)
+	assert.NotContains(t, string(patch), "resourceVersion")
+}
+
+func TestInjectResourceVersion(t *testing.T) {
+	// merges into existing metadata
+	out, err := InjectResourceVersion([]byte(`{"metadata":{"annotations":{"a":"b"}},"spec":{"x":1}}`), "99")
+	assert.Nil(t, err)
+	assert.Contains(t, string(out), `"resourceVersion":"99"`)
+	assert.Contains(t, string(out), `"a":"b"`)
+
+	// adds metadata when missing
+	out, err = InjectResourceVersion([]byte(`{"spec":{"x":1}}`), "99")
+	assert.Nil(t, err)
+	assert.Contains(t, string(out), `"resourceVersion":"99"`)
+
+	// no-op on empty resourceVersion
+	out, err = InjectResourceVersion([]byte(`{"spec":{"x":1}}`), "")
+	assert.Nil(t, err)
+	assert.Equal(t, `{"spec":{"x":1}}`, string(out))
+}


### PR DESCRIPTION
Status patches were sent with an empty PatchOptions and a merge-patch body
that carried no metadata.resourceVersion, so there was no optimistic
concurrency: a write that landed between the (possibly stale) cache read and
the patch was silently overwritten.

Add diff.CreateTwoWayMergePatchWithResourceVersion / diff.InjectResourceVersion
to embed metadata.resourceVersion into merge/strategic-merge patch bodies, and
use them where clobbering a concurrent foreign write is a correctness risk:

- AnalysisRun status (analysis/sync.go)
- Experiment status (experiments/controller.go, experiments/replicaset.go)
- Service selector switch (rollout/service.go) and Service cleanup (service/service.go)

On a 409 Conflict these requeue via controllerutil.StaleCacheError instead of
failing. To ensure a conflict can only come from a genuine foreign write (and
not a self-induced stale read), extend the resourceversion.Tracker +
IsCacheStale guard added in #4786 to the analysis and experiments controllers.

High-churn or idempotent patches are intentionally left version-less: rollout
status/conditions (HPA churns the shared object resourceVersion and the
controller is the sole status writer), ReplicaSet annotation JSONPatches,
cancelAnalysisRun, traffic-router/ingress patches, and the kubectl commands.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GdX2c8Z8PgU6ncyLB6XsG4