### PR TITLE
docs: add Claude Code skills for repo development workflows

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: architecture
+description: Map of the Argo Rollouts codebase and how its pieces fit together. Use when planning a feature, deciding where new code belongs, tracing how a Rollout is reconciled, or answering "where does X happen" questions about the controller, traffic routing, analysis, experiments, CLI/plugin, or UI.
+---
+
+# Argo Rollouts Architecture
+
+Argo Rollouts is a Kubernetes controller (plus a kubectl plugin and web UI) that provides
+progressive delivery: blue-green and canary strategies for a `Rollout` resource that
+replaces a Deployment, with optional analysis-driven promotion and traffic shaping.
+
+## High-level components
+
+| Component | Entry point | Purpose |
+|---|---|---|
+| Controller manager | `cmd/rollouts-controller/main.go` → `controller/controller.go` | Wires informers, clients, and starts all sub-controllers |
+| Rollout controller | `rollout/controller.go` | Core reconciler for `Rollout` resources |
+| Analysis controller | `analysis/` | Reconciles `AnalysisRun`s, executes metric measurements |
+| Experiment controller | `experiments/` | Reconciles `Experiment` resources (ephemeral ReplicaSets + analysis) |
+| Service/Ingress controllers | `service/`, `ingress/` | Manage rollout-referenced Services and Ingresses |
+| Metric providers | `metricproviders/` | Prometheus, Datadog, CloudWatch, Kayenta, Job, web, plugin, etc. |
+| Traffic routers | `rollout/trafficrouting/` | Istio, ALB, NGINX, SMI, Ambassador, AppMesh, Traefik, Apisix, plugin |
+| kubectl plugin / CLI | `pkg/kubectl-argo-rollouts/` | `kubectl argo rollouts` commands (get, promote, abort, dashboard…) |
+| API server + UI | `server/`, `ui/` | gRPC/REST API (`pkg/apiclient/rollout/rollout.proto`) and React dashboard |
+| API types | `pkg/apis/rollouts/v1alpha1/types.go` | CRD Go types — source of truth for generated code |
+| Generated clients | `pkg/client/` | clientset/informers/listers generated from types.go |
+| Shared helpers | `utils/` | One package per concern (replicaset, analysis, conditions, defaults, istio, aws…) |
+
+## Reconciliation flow (rollout controller)
+
+1. Informer event handlers in `rollout/controller.go` enqueue rollout keys onto a rate-limited
+   workqueue (`utils/controller` has the generic worker plumbing).
+2. `syncHandler` builds a `rolloutContext` (`rollout/context.go`) holding the rollout, its
+   stable/new/old ReplicaSets, current/pending AnalysisRuns, and the resolved traffic router.
+3. Strategy logic lives in `rollout/canary.go` and `rollout/bluegreen.go`; shared
+   ReplicaSet scaling/creation in `rollout/replicaset.go` and `rollout/sync.go`;
+   pausing in `rollout/pause.go`; analysis orchestration in `rollout/analysis.go`;
+   traffic weight changes in `rollout/trafficrouting.go`; canary step plugins in
+   `rollout/stepplugin.go`.
+4. Status is written back via a computed patch (`calculateRolloutConditions` /
+   `persistRolloutStatus` in `rollout/sync.go`) — the controller patches status, it does not
+   update the whole object.
+
+Key invariant: reconciliation must be idempotent and converge. Everything derives from
+observed cluster state + the Rollout spec; avoid state that only lives in memory.
+
+## Where new code goes
+
+- New canary/bluegreen behavior → `rollout/` (+ unit tests in the same package).
+- New metric provider → `metricproviders/<name>/` (see `extend-providers` skill).
+- New traffic router → `rollout/trafficrouting/<name>/` (see `extend-providers` skill).
+- New API field → `pkg/apis/rollouts/v1alpha1/types.go`, then **must** run codegen
+  (see `codegen` skill) and update validation in `pkg/apis/rollouts/validation/`.
+- New CLI command → `pkg/kubectl-argo-rollouts/cmd/`.
+- Cross-cutting helpers → a focused package under `utils/`.
+- Install manifests → `manifests/` (regenerated via `make manifests`; CRDs via `make gen-crd`).
+
+## Extensibility
+
+Three plugin systems (all hashicorp/go-plugin RPC based, configured via the
+`argo-rollouts-config` ConfigMap): metric plugins (`metricproviders/plugin/`), traffic router
+plugins (`rollout/trafficrouting/plugin/`), and canary step plugins (`rollout/steps/plugin/`).
+Sample plugins live under `test/cmd/`.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: code-review
+description: Repo-specific checklist for reviewing argo-rollouts changes — reconciler correctness, API/CRD compatibility, generated-code hygiene, test coverage expectations, and provider parity. Use when reviewing a PR or diff, or self-reviewing before pushing.
+---
+
+# Reviewing Argo Rollouts Changes
+
+Apply general review judgment plus these repo-specific checks.
+
+## Reconciler correctness (highest-value area)
+
+- **Idempotence**: would a second sync with the post-change state mutate anything again?
+  Reconcile must converge; look for unconditional writes, or decisions based on values
+  the same sync just wrote.
+- **Informer cache staleness**: objects from listers are shared and possibly stale.
+  Flag mutation of lister-returned objects without `DeepCopy()`, and logic that assumes
+  a just-created object is immediately visible in the cache.
+- **Status handling**: status changes must flow through the existing patch path in
+  `rollout/sync.go` (`persistRolloutStatus`) — not ad-hoc `Update` calls.
+  `observedGeneration` and conditions should stay consistent with the new behavior.
+- **Abort/pause/promote paths**: any change to canary/bluegreen progression needs to be
+  checked against abort, retry, manual promote, and rollback-within-window flows, not
+  just the happy path.
+- **Requeue behavior**: `enqueueRolloutAfter` durations and rate-limiter interactions —
+  watch for hot loops (requeue every sync) or lost wakeups (state that changes with no
+  event and no requeue).
+
+## API / compatibility
+
+- Changes to `pkg/apis/rollouts/v1alpha1/types.go`: additive only; correct
+  json/protobuf tags; `+optional` markers; field numbers unique and never recycled;
+  validation added in `pkg/apis/rollouts/validation/`; defaults in `utils/defaults`.
+- If `types.go` changed, the diff **must** include regenerated code (deepcopy, proto,
+  openapi, client, CRDs in `manifests/crds/`) — a types-only diff means codegen was
+  skipped. Conversely, hand edits inside generated files are a red flag (see the
+  `refactoring` skill for the list of generated paths).
+- Behavior changes affecting existing rollouts mid-upgrade (hash computation,
+  annotations, scaling defaults) need explicit justification and upgrade notes.
+
+## Tests and docs
+
+- Controller changes need fixture tests asserting the exact action/patch sequence
+  (see `testing` skill); bug fixes need a test that fails without the fix.
+- New user-facing behavior needs docs under `docs/` (mkdocs site) and, if it adds
+  spec fields, examples in `docs/features/` and possibly `examples/`.
+- E2E coverage expected for new strategies/steps/traffic behavior (`test/e2e/`).
+
+## Provider parity and plugins
+
+- A fix in one traffic router or metric provider often applies to its siblings —
+  check whether the same bug exists in the other `rollout/trafficrouting/*` or
+  `metricproviders/*` implementations and say so in the review.
+- Plugin interface changes (`rollout/steps/plugin`, `metricproviders/plugin`,
+  `rollout/trafficrouting/plugin`) are cross-process RPC contracts: breaking them
+  breaks third-party plugins; mocks must be regenerated.
+
+## Hygiene
+
+- Errors wrapped with context; no swallowed errors in reconcile paths (returning nil
+  on error usually means the rollout silently stalls).
+- Logging via the structured logger with rollout/namespace fields, at an appropriate
+  level (debug for per-sync noise).
+- No `time.Sleep` in tests; use existing time injection (`utils/time`).
+- DCO sign-off (`Signed-off-by`) is required on commits in this project.

--- a/.claude/skills/codegen/SKILL.md
+++ b/.claude/skills/codegen/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: codegen
+description: How to regenerate all generated code in argo-rollouts after editing API types, proto files, or mocked interfaces — deepcopy, clientsets, protobuf, openapi, CRDs, manifests, mocks, and docs. MANDATORY after any change to pkg/apis/rollouts/v1alpha1/types.go. Use when adding/changing API fields, changing rollout.proto, or when CI codegen-diff checks fail.
+---
+
+# Code Generation
+
+CI verifies that generated code matches its sources; a `types.go` change without
+regenerated outputs will fail the build. Everything is driven from the Makefile.
+
+## The full pipeline
+
+```bash
+make install-tools-local   # one-time: codegen CLIs + protoc into ./dist (PATH-prepended)
+make codegen               # gen-proto gen-k8scodegen gen-openapi gen-mocks gen-crd manifests docs
+```
+
+`make codegen` is slow. Run only the targets your change requires:
+
+| You changed | Run | Regenerates |
+|---|---|---|
+| `pkg/apis/rollouts/v1alpha1/types.go` | `make gen-k8scodegen` | deepcopy + `pkg/client/` (clientset, informers, listers) via `hack/update-codegen.sh` |
+| same | `make k8s-proto api-proto` | `generated.proto`, `generated.pb.go`, apiclient pb/gateway/swagger |
+| same | `make gen-openapi` | `openapi_generated.go` + violation exceptions list |
+| same | `make gen-crd` | `manifests/crds/*.yaml` (via `hack/gen-crd-spec`) |
+| same | `make manifests` | `manifests/install.yaml`, `namespace-install.yaml` |
+| `pkg/apiclient/rollout/rollout.proto` | `make api-proto` then `pnpm --dir ui run protogen` | Go pb + gateway + swagger, then UI TS models |
+| A mocked interface (`metric.Provider`, `TrafficRoutingReconciler`, step plugin ifaces) | `make gen-mocks` | `*/mocks/` (interfaces listed in `hack/update-mocks.sh`) |
+| CLI commands / notification docs | `make docs` | generated docs under `docs/` |
+
+Practical order for a types.go change:
+`gen-k8scodegen → k8s-proto → api-proto → gen-openapi → gen-crd → manifests`.
+
+## Rules for editing types.go
+
+- Additive changes only; never reuse or renumber `protobuf=` field numbers in tags.
+- Every field needs json + protobuf tags and doc comments (they become CRD/openapi docs);
+  optional fields need `+optional` and a pointer or omitempty as appropriate.
+- Add validation in `pkg/apis/rollouts/validation/` and defaulting in `utils/defaults`.
+- New openapi violations may need entries in `pkg/apis/api-rules/violation_exceptions.list`
+  (gen-openapi maintains it).
+
+## Gotchas
+
+- Tools install into `./dist` and the Makefile prepends it to PATH — don't install
+  global versions to "fix" missing tools; run `make install-go-tools-local` /
+  `install-protoc-local`.
+- Codegen runs `go mod vendor` (`go-mod-vendor` target); a dirty `vendor/` diff
+  afterwards is expected if deps changed, otherwise revert stray vendor noise.
+- proto generation briefly creates `github.com/` and `k8s.io/` dirs in the repo root;
+  the Makefile cleans them up — if a run aborted, `make clean` or delete them manually.
+- Commit generated changes together with the source change, and never hand-edit
+  generated files (list in the `refactoring` skill).

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: debugging
+description: Techniques for debugging the Argo Rollouts controller and tests — running the controller locally against a cluster, log levels, tracing a stuck or misbehaving Rollout through the reconcile loop, and debugging flaky unit/e2e tests. Use when investigating bugs, unexpected rollout behavior, or test failures.
+---
+
+# Debugging Argo Rollouts
+
+## Run the controller locally
+
+The controller runs fine outside the cluster against your kubeconfig context:
+
+```bash
+kubectl create ns argo-rollouts                      # once
+kubectl apply --server-side -k manifests/crds        # install CRDs
+go run ./cmd/rollouts-controller/main.go --loglevel debug --kloglevel 6
+```
+
+- `--loglevel debug` for controller logs (logrus), `--kloglevel 6` for client-go/informer
+  internals (watch events, queue activity).
+- `--instance-id <id>` restricts reconciliation to Rollouts labeled
+  `argo-rollouts.argoproj.io/controller-instance-id=<id>` — useful to avoid fighting an
+  in-cluster controller.
+- Scale down any in-cluster controller first, or two controllers will fight over status.
+- Delve: `dlv debug ./cmd/rollouts-controller -- --loglevel debug`. Sample plugins have
+  debug builds: `make build-sample-metric-plugin-debug` etc.
+
+## Tracing a misbehaving Rollout
+
+Logs are structured with `namespace=... rollout=...` fields — grep on the rollout name to
+follow one object's reconciles. The reconcile entry point is `syncHandler` in
+`rollout/controller.go`; each sync builds a `rolloutContext` (`rollout/context.go`).
+
+Checklist for "rollout is stuck/wrong":
+
+1. `kubectl argo rollouts get rollout <name>` (or `kubectl get rollout -o yaml`) — read
+   `status`: `phase`, `message`, `pauseConditions`, `abort`, `currentStepIndex`,
+   `canary.weights`, and `conditions`.
+2. Check events: the controller emits reasons like `RolloutUpdated`, `NewReplicaSetCreated`,
+   `RolloutStepCompleted`, `RolloutAborted` (`utils/record`).
+3. Find which code path decided the state: step progression in `rollout/canary.go`
+   (`reconcileCanaryReplicaSets`, step handling), pauses in `rollout/pause.go`, abort/analysis
+   verdicts in `rollout/analysis.go`, traffic weight in `rollout/trafficrouting.go`, and the
+   final status computation in `rollout/sync.go` (`calculateRolloutConditions`,
+   `persistRolloutStatus`).
+4. For traffic routing issues, inspect the generated mesh/ingress resources (VirtualService,
+   ALB annotations, canary Ingress) — routers live in `rollout/trafficrouting/<provider>/`.
+5. For analysis issues, inspect the `AnalysisRun` object status; measurement logic is in
+   `metricproviders/<provider>/` and run bookkeeping in `analysis/controller.go`.
+
+Common root causes: status patch conflicts (another controller/human writing status),
+`observedGeneration` lag, informer cache staleness right after a write, missing
+`instance-id` label, and ReplicaSet hash collisions (see `utils/hash`, pod-template-hash).
+
+## Debugging tests
+
+- Rerun one test verbosely: `go test ./rollout/ -run TestFoo -v -count=1`.
+- Fixture tests fail with "unexpected action" / "expected action ... didn't happen": dump
+  `f.kubeclient.Actions()` in the failure to see the actual sequence; ordering matters.
+- Enqueue-count mismatches usually mean your change added/removed a requeue — adjust
+  `f.runWithSyncs`/expectations deliberately, don't just bump numbers until green.
+- Flaky time-dependent tests: this codebase injects time via `timeutil` (`utils/time`) —
+  use/extend the existing override hooks rather than `time.Sleep`.
+- E2E failures: see the `e2e-testing` skill; check controller output in the `start-e2e`
+  terminal and the test's dumped state before assuming the test is wrong.

--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: e2e-testing
+description: Running and writing argo-rollouts end-to-end tests — cluster setup, the Given/When/Then fixture DSL in test/fixtures, test suites, and running a single e2e test. Use when a change needs e2e coverage, when investigating e2e CI failures, or when asked to run tests in test/e2e.
+---
+
+# E2E Testing
+
+E2E tests (`test/e2e/`, build tag `e2e`) run against a **real cluster** with a rollouts
+controller running. They cannot run without one — don't attempt `make test-e2e` in an
+environment with no Kubernetes cluster; rely on unit tests and CI instead.
+
+## Environment setup
+
+```bash
+k3d cluster create                                  # or any cluster; kind works too
+kubectl create ns argo-rollouts
+kubectl apply --server-side -k manifests/crds
+kubectl apply --server-side -f test/e2e/crds
+make start-e2e          # runs the controller locally with --instance-id argo-rollouts-e2e
+```
+
+In another terminal:
+
+```bash
+make test-e2e                                            # everything (~long, retries flakes)
+E2E_TEST_OPTIONS="-run 'TestCanarySuite' -testify.m 'TestCanaryScaleDownOnAbort'" make test-e2e
+```
+
+Knobs: `E2E_K8S_CONTEXT` (default `rancher-desktop`) used by `make setup-e2e`,
+`E2E_PARALLEL`, `E2E_WAIT_TIMEOUT`, `E2E_INSTANCE_ID`. Traffic-router suites (Istio, ALB,
+SMI, APISIX, ...) additionally need that mesh/ingress installed in the cluster; the
+plain `TestFunctionalSuite`, `TestCanarySuite`, `TestBlueGreenSuite` do not.
+Step-plugin tests need `make setup-e2e` (builds the sample plugin binary and applies
+`test/e2e/step-plugin/argo-rollouts-config.yaml`).
+
+## Test structure: Given / When / Then
+
+Suites embed `fixtures.E2ESuite` (testify suite). Tests are a fluent chain defined in
+`test/fixtures/{given,when,then}.go`:
+
+```go
+func (s *FunctionalSuite) TestExample() {
+	s.Given().
+		RolloutObjects("@functional/my-rollout.yaml").  // @path = file under test/e2e/
+		When().
+		ApplyManifests().
+		WaitForRolloutStatus("Healthy").
+		UpdateSpec().                                   // bumps pod template to trigger update
+		WaitForRolloutStatus("Paused").
+		PromoteRollout().
+		WaitForRolloutStatus("Healthy").
+		Then().
+		ExpectRevisionPodCount("2", 4).
+		ExpectRolloutStatus("Healthy").
+		ExpectAnalysisRunCount(1).
+		When().                                          // chains can go back to When()
+		AbortRollout().
+		WaitForRolloutStatus("Degraded")
+}
+```
+
+- Inline YAML is also accepted by `RolloutObjects`/`HealthyRollout` (raw string arg).
+- Each test's objects are named uniquely and cleaned up by the suite between tests;
+  tests must be self-contained and parallel-safe (`E2E_PARALLEL`).
+- Common assertions live in `then.go` (`ExpectReplicaCounts`, `ExpectCanaryStablePodCount`,
+  `ExpectServiceSelector`, `ExpectRolloutEvents`, ...) and waits in `when.go`
+  (`WaitForRolloutStatus`, `WaitForRolloutCanaryStepIndex`, `Sleep` — avoid `Sleep`,
+  prefer a Wait on observable state).
+- Suite fixtures/manifests live under `test/e2e/<suite-dir>/`; shared analysis templates
+  under `test/e2e/functional/`.
+
+## Writing a new e2e test
+
+1. Pick the matching suite file (`canary_test.go`, `bluegreen_test.go`,
+   `functional_test.go`, provider-specific files) — only create a new suite for a new
+   subsystem.
+2. Keep it minimal: smallest replica counts and shortest step durations that still prove
+   the behavior; e2e minutes are expensive and flaky-prone.
+3. If the test is slow, guard with `s.T().Skip` on `testing.Short()` patterns only if
+   existing tests in that suite do so (the Makefile passes `--short`... check siblings).
+4. Reproduce a CI flake locally with `-count 1` and the exact `-testify.m` regex before
+   changing waits; most flakes are missing Wait conditions, not broken product code.

--- a/.claude/skills/extend-providers/SKILL.md
+++ b/.claude/skills/extend-providers/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: extend-providers
+description: How to add a new metric provider, traffic router, or plugin support to Argo Rollouts — the interfaces to implement, registration points, API types, and required tests/docs. Use when adding integration with a new metrics backend (e.g. a new APM) or a new service mesh / ingress controller.
+---
+
+# Extending Argo Rollouts (Providers, Routers, Plugins)
+
+First question: **built-in or plugin?** New integrations are increasingly preferred as
+plugins (separate repo, hashicorp/go-plugin RPC, loaded via the `argo-rollouts-config`
+ConfigMap) rather than built-ins compiled into the controller. Check with maintainers
+before adding a new built-in. Sample plugins: `test/cmd/metrics-plugin-sample/`,
+`test/cmd/trafficrouter-plugin-sample/`, `test/cmd/step-plugin-sample/`.
+
+## Adding a built-in metric provider
+
+1. Implement `metric.Provider` (defined in `metric/` at the repo root):
+   `Run`, `Resume`, `Terminate`, `GarbageCollect`, `Type`, `GetMetadata`.
+   Put it in `metricproviders/<name>/`.
+2. Add the config struct to `MetricProvider` in
+   `pkg/apis/rollouts/v1alpha1/analysis_types.go` (one field per provider) —
+   then run full codegen (see `codegen` skill).
+3. Register it in `metricproviders/metricproviders.go` (`NewProvider` switch and
+   `Type()` dispatch).
+4. Validation in `pkg/apis/rollouts/validation/` if the config has constraints;
+   secret resolution follows the existing pattern (namespaced Secret lookups —
+   copy from a sibling like `datadog` or `newrelic`).
+5. Tests: unit tests against an `httptest.Server` or mocked SDK (copy a sibling's
+   pattern). Measurement results must set `Phase`, `Value`, and `Measurement` timestamps
+   consistently with other providers.
+6. Docs: add `docs/analysis/<name>.md` and wire it into `mkdocs.yml` nav.
+
+## Adding a built-in traffic router
+
+1. Implement `TrafficRoutingReconciler` (defined in `rollout/trafficrouting/`):
+   `SetWeight`, `SetHeaderRoute`, `SetMirrorRoute`, `VerifyWeight`, `RemoveManagedRoutes`,
+   `UpdateHash`, `Type`. Put it in `rollout/trafficrouting/<name>/`.
+   Routers that can't verify weight return `nil` from `VerifyWeight` per the existing
+   convention — check siblings (`nginx` simple, `istio`/`alb` complex references).
+2. Add the config struct to `RolloutTrafficRouting` in
+   `pkg/apis/rollouts/v1alpha1/types.go` → full codegen.
+3. Register in `rollout/trafficrouting.go` (`NewTrafficRoutingReconciler`).
+4. RBAC: the controller needs rules for any new resource types it manages — update
+   role manifests under `manifests/` (then `make manifests`).
+5. Tests: unit tests with fake dynamic/typed clients like siblings; an e2e suite
+   (`test/e2e/<name>_test.go` + fixture manifests) gated on that provider being
+   installed.
+6. Docs: `docs/features/traffic-management/<name>.md` + `mkdocs.yml`.
+
+## Plugin interface changes
+
+The RPC interfaces live in `metricproviders/plugin/`, `rollout/trafficrouting/plugin/`,
+and `rollout/steps/plugin/` (types shared with plugin authors in
+`utils/plugin/`/`rpc` subpackages). These are cross-process contracts consumed by
+third-party plugins — changes must be backward compatible, and mocks regenerated
+(`make gen-mocks`). Plugin resolution/download logic is in `utils/plugin/`.
+
+## Definition of done (any provider)
+
+- Codegen artifacts committed (types, deepcopy, proto, openapi, CRDs, clients).
+- Sibling parity: supports the same secret handling, address overrides, and dry-run
+  semantics as comparable providers where applicable.
+- Docs page + example manifest; mention in feature matrix if one exists for that area.

--- a/.claude/skills/refactoring/SKILL.md
+++ b/.claude/skills/refactoring/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: refactoring
+description: Guardrails for refactoring the argo-rollouts codebase safely — what is generated vs hand-written, API compatibility constraints, package layering, and the verification loop. Use when renaming, moving, extracting, or restructuring code, or cleaning up an area you're already touching.
+---
+
+# Refactoring in Argo Rollouts
+
+## Never hand-edit generated code
+
+A large fraction of this repo is generated. If a refactor touches these, change the
+source and regenerate (see the `codegen` skill) instead of editing outputs:
+
+- `pkg/apis/rollouts/v1alpha1/`: `zz_generated.deepcopy.go`, `generated.pb.go`,
+  `generated.proto`, `openapi_generated.go` — generated from `types.go`.
+- `pkg/client/` — entire tree (clientset/informers/listers) generated from `types.go`.
+- `pkg/apiclient/rollout/*.pb.go`, `*.pb.gw.go`, `*.swagger.json` — from `rollout.proto`.
+- `*/mocks/*` — mockery output (`make gen-mocks`).
+- `manifests/crds/*` and `manifests/install.yaml`/`namespace-install.yaml` —
+  `make gen-crd` / `make manifests`.
+- `docs/generated/` and CLI docs — `make docs`.
+- `ui/src/models/` — generated from swagger.
+
+## Compatibility constraints
+
+- `pkg/apis/rollouts/v1alpha1/types.go` is a public API. Renaming fields, changing JSON
+  tags, or changing types breaks every user's manifests — don't do it as part of a
+  refactor. Additive changes only, and they require full codegen + validation updates.
+- Protobuf field numbers in `rollout.proto` must never be reused or renumbered.
+- The kubectl plugin (`pkg/kubectl-argo-rollouts/`) is used as a library by other
+  projects; treat its exported surface conservatively.
+- Rollout status fields and annotations (e.g. `rollout.argoproj.io/revision`,
+  pod-template-hash behavior in `utils/hash`) are load-bearing across upgrades —
+  changing their semantics can strand existing rollouts mid-update.
+
+## Layering rules
+
+- `utils/*` packages are leaf helpers: they may depend on `pkg/apis` and client-go but
+  must not import controller packages (`rollout`, `analysis`, `experiments`, ...).
+- Controller packages may depend on `utils/*` and `pkg/*`; keep provider-specific logic
+  inside its provider package (`metricproviders/<p>`, `rollout/trafficrouting/<p>`),
+  behind the shared interfaces (`metric.Provider`, `TrafficRoutingReconciler`).
+- Prefer extracting into an existing focused `utils/<topic>` package over creating
+  grab-bag helpers in controller packages.
+
+## Refactoring loop
+
+1. Confirm a green baseline first: `go build ./... && go test ./<affected>/...`.
+2. Make the mechanical change (gopls-style rename over sed where possible; if using
+   grep, remember string literals in tests, YAML fixtures under `test/`, and docs may
+   reference identifiers/annotations).
+3. `make lint` (golangci-lint with `--fix`) and `go build ./...`.
+4. Run unit tests for every package you touched, then the full `make test-unit` before
+   pushing. If behavior around reconciliation changed at all, it's not a refactor —
+   add/adjust fixture tests (see `testing` skill).
+5. Keep refactor commits separate from behavior changes so reviewers can diff them
+   mechanically.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: testing
+description: How to write and run tests in argo-rollouts — unit tests with the fake-client fixture pattern, kustomize manifest tests, and pointers to the e2e suite. Use whenever adding or modifying tests, running the test suite, or verifying a controller change.
+---
+
+# Testing Argo Rollouts
+
+## Running tests
+
+```bash
+make test-unit                 # all unit tests via gotestsum (installs devtools into ./dist)
+go test ./rollout/...          # faster: plain go test on the package you touched
+go test ./rollout/ -run TestName -v
+make test-kustomize            # validates manifests/ kustomize overlays build
+make test                      # kustomize + unit
+make lint                      # golangci-lint run --fix (runs go mod tidy/vendor first)
+```
+
+`kustomize` must be installed for `make test`. E2E tests need a real cluster — see the
+`e2e-testing` skill; never try to run `make test-e2e` without one.
+
+## Unit test conventions
+
+- Tests are table-driven where natural, use `stretchr/testify` (`assert`/`require`), and
+  live next to the code (`foo.go` → `foo_test.go`, same package).
+- Controller behavior tests use the **fixture pattern** in `rollout/controller_test.go`:
+  `newFixture(t)` builds a controller backed by `k8sfake`/rollout fake clientsets.
+  You seed objects into `f.rolloutLister`, `f.replicaSetLister`, `f.objects`,
+  `f.kubeobjects`, declare expected client actions with `f.expectPatchRolloutAction(r)`,
+  `f.expectUpdateReplicaSetAction(rs)`, `f.expectCreateReplicaSetAction(rs)` etc.,
+  then call `f.run(getKey(rollout, t))`. Unexpected or missing actions fail the test.
+  Helpers like `newCanaryRollout`, `newBlueGreenRollout`, `newReplicaSetWithStatus`,
+  and `updateCanaryRolloutStatus` construct realistic objects — reuse them instead of
+  building objects by hand.
+- Assert status patches by capturing the patch index
+  (`patchIndex := f.expectPatchRolloutAction(r)`) and comparing against
+  `f.getPatchedRollout(patchIndex)` — many tests compare against an expected JSON patch
+  string with `calculatePatch`.
+- Analysis/experiment controllers have their own analogous fixtures
+  (`analysis/controller_test.go`, `experiments/controller_test.go`).
+- Mocks are generated with mockery via `make gen-mocks` (`hack/update-mocks.sh` lists
+  each mocked interface explicitly; output goes to `*/mocks/`). Never hand-edit mock
+  files; if an interface changed, regenerate — and add a new mockery stanza to the
+  script when mocking a new interface.
+- Metric providers are tested against `httptest` servers or mocked SDK clients — follow
+  the existing pattern in the sibling provider package.
+
+## What to test for a controller change
+
+1. The happy-path reconcile produces exactly the expected actions/patch.
+2. Idempotence: a second sync with the resulting state produces no new mutations.
+3. Edge states relevant to the change: paused, aborted, degraded, scaled-to-zero,
+   mid-step canary, missing stable ReplicaSet.
+4. If you touched `pkg/apis/rollouts/validation/`, add cases to its table tests.
+
+Do not assert on log output; assert on actions, status patches, and events
+(`f.expectPatchRolloutAction`, recorder events via `utils/record` fake recorder).


### PR DESCRIPTION
Adds .claude/skills covering architecture, testing, debugging,
refactoring, code review, code generation, e2e testing, and
extending providers/traffic routers/plugins, tailored to the
argo-rollouts codebase and Makefile targets.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ECMwxAvvbQnA6kqq7BbD1W
Signed-off-by: Zach Aller <allerzach@gmail.com>